### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# AGENTS.md
+
+Guidance for AI agents working in this repository.
+
+## Project overview
+
+This is the **O1 Containers Collection**: a monorepo of independent Docker images for Web3 node software (Avalanche, Besu, Bitcoin, Cosmos Gaia, Ethereum clients, etc.). There is no root application server—development means building and running individual service directories.
+
+See [README.md](README.md) for container options (`RUN_ARGS`, config mounts, custom entrypoints).
+
+## Cursor Cloud specific instructions
+
+### Prerequisites
+
+- **Docker** is required for all build/run workflows. CI uses `docker build` and `docker-compose`/`docker compose`.
+- **Python 3 + `yq`** (via pip) is used in GitHub Actions to read `meta.yml` version fields during CI/CD.
+
+### Starting Docker in Cloud Agent VMs
+
+If `docker` fails with permission or connection errors:
+
+1. Ensure the daemon is running: `sudo service docker start` (or `sudo dockerd > /tmp/dockerd.log 2>&1 &` if systemd is unavailable).
+2. Use `sudo docker` / `sudo docker compose` until the session user is in the `docker` group (requires re-login after `usermod -aG docker $USER`).
+
+This VM uses `fuse-overlayfs` as the Docker storage driver (`/etc/docker/daemon.json`).
+
+### Running a service
+
+Each top-level directory (e.g. `avalanchego/`, `gaia/`, `besu/`) has its own `Dockerfile`, `docker-compose.yaml`, `meta.yml`, and `config/`.
+
+```bash
+cd avalanchego
+network=local docker compose up -d --build   # local dev config
+docker compose down
+```
+
+- Set `network=local` to use `./config/local` instead of mainnet defaults.
+- Set `host_data_dir` to override the named volume path for chain data.
+- Avoid running multiple stacks that bind the same host ports (e.g. `8545` for Besu/Erigon/Nethermind; `8332` for bitcoind/bitcoin-abcd).
+
+### CI-equivalent smoke test
+
+Matches [.github/workflows/CI.yaml](.github/workflows/CI.yaml):
+
+```bash
+dir=avalanchego
+version=$(cat $dir/meta.yml | yq -r .version)
+docker build $dir/ --file $dir/Dockerfile --build-arg VERSION=$version --tag 0labs/$dir:$version
+docker compose -f $dir/docker-compose.yaml up -d --build
+docker compose -f $dir/docker-compose.yaml down
+```
+
+GitHub Actions invokes the standalone `docker-compose` CLI; `docker compose` (Compose plugin) is equivalent.
+
+### Lint / tests
+
+There is no repo-wide linter or unit test suite. Validation is **Docker image build + compose up/down** per changed service directory, as in CI.
+
+### Hello-world verification (example: avalanchego)
+
+```bash
+cd avalanchego && network=local docker compose up -d --build
+curl -s -X POST --data '{"jsonrpc":"2.0","id":1,"method":"info.getNodeVersion"}' \
+  -H 'content-type:application/json' http://127.0.0.1:9650/ext/info
+curl -s -X POST --data '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}' \
+  -H 'content-type:application/json' http://127.0.0.1:9650/ext/bc/C/rpc
+docker compose down
+```
+
+### Build-time notes
+
+- **Fast builds** (prebuilt binaries): `avalanchego`, `bitcoind`, `litecoin`, etc.
+- **Slow builds** (compile from source): `gaia`, `erigon`, `besu`, `nethermind`, `lodestar`, `mev-boost`, `nimbus`.
+- Validator stacks (Lodestar/Nimbus) may reference external execution clients not defined in this repo.
+
+### Maintainer CI/CD tools (optional on host)
+
+CD and utilities workflows also use `jinja-cli` and `jq` via pip/apt; only needed when editing release automation, not for container smoke tests.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment guidance for Cloud Agents working in this Docker-first Web3 containers monorepo.

## What's documented

- How to start Docker in Cloud Agent VMs (`fuse-overlayfs` storage driver)
- Per-service compose workflow (`network=local`, port conflict notes)
- CI-equivalent smoke test commands (build + compose up/down)
- Example hello-world RPC checks for `avalanchego`

## Environment verification performed

- Installed Docker CE + Compose plugin
- Built `0labs/avalanchego:1.10.5` image
- Ran compose up/down smoke test
- Verified JSON-RPC endpoints:
  - `info.getNodeVersion` → `avalanche/1.9.8` (image build arg vs bundled binary)
  - `eth_blockNumber` on C-chain → `0x0`

## VM update script

Minimal pip refresh for CI tooling: `yq` (no application package dependencies in this repo).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-238326d7-2d7f-4299-9dfc-6a14a0c5c4d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-238326d7-2d7f-4299-9dfc-6a14a0c5c4d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

